### PR TITLE
fix: Add missing Switch and Label UI components

### DIFF
--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+import { cva, type VariantProps } from "class-variance-authority" // cva might not be strictly necessary here but often included
+
+import { cn } from "@/lib/utils"
+
+// Base styling for the switch, derived from typical ShadCN setups.
+// It uses data-state attributes for checked/unchecked states.
+const switchRootVariants = cva(
+  "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+  {
+    variants: {}, // No specific variants defined here, but structure allows for it
+    defaultVariants: {},
+  }
+)
+
+const switchThumbVariants = cva( // Also define thumb variants if you want to customize it via cva
+    "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+)
+
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & VariantProps<typeof switchRootVariants>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(switchRootVariants(), className)}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb className={cn(switchThumbVariants())} />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }


### PR DESCRIPTION
Adds the source files for `frontend/src/components/ui/switch.tsx` and `frontend/src/components/ui/label.tsx`. These components were being imported by `InputForm.tsx` but their source files were missing from the repository, causing TypeScript compilation errors during the Docker build process (TS2307: Cannot find module).

This commit provides the standard ShadCN UI implementations for these components, which should resolve the build failure.