### PR TITLE
fix: Add missing Radix UI dependencies for Label and Switch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@langchain/core": "^0.3.55",
     "@langchain/langgraph-sdk": "^0.0.74",
+    "@radix-ui/react-label": "^1.0.0",
     "@radix-ui/react-scroll-area": "^1.2.8",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-slot": "^1.2.2",
+    "@radix-ui/react-switch": "^1.0.0",
     "@radix-ui/react-tabs": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@tailwindcss/vite": "^4.1.5",


### PR DESCRIPTION
Adds `@radix-ui/react-label` and `@radix-ui/react-switch` to the `dependencies` in `frontend/package.json`.

These packages are required by the `label.tsx` and `switch.tsx` ShadCN UI components but were not previously listed as dependencies, leading to TypeScript errors (TS2307: Cannot find module) during the frontend build process within Docker.

This change ensures that these dependencies are installed, allowing the project to build successfully.